### PR TITLE
Log when wp_cache_flush() is called

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -118,6 +118,21 @@ function wp_cache_delete_group( $group ) {
 function wp_cache_flush() {
 	global $wp_object_cache;
 
+	if ( function_exists( 'wp_debug_backtrace_summary' ) ) {
+		$trace = wp_debug_backtrace_summary();
+	} else {
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+		$caller    = array_shift( $backtrace );
+		$trace =  $caller['file'], $caller['line'];
+	}
+	error_log( sprintf( 'wp_cache_flush() requested from ' . $trace ) )
+
+	if ( 'cli' !== php_sapi_name() ) {
+		$allowed = apply_filters( 'wp_cache_flush_allowed_non_cli', true );
+		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called from %s', $trace ), E_USER_WARNING );
+		return false;
+	}
+
 	return $wp_object_cache->flush();
 }
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -129,8 +129,10 @@ function wp_cache_flush() {
 
 	if ( 'cli' !== php_sapi_name() ) {
 		$allowed = apply_filters( 'wp_cache_flush_allowed_non_cli', true );
-		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called from %s', $trace ), E_USER_WARNING );
-		return false;
+		if ( ! $allowed ) {
+			trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called from %s', $trace ), E_USER_WARNING );
+			return false;
+		}
 	}
 
 	return $wp_object_cache->flush();


### PR DESCRIPTION
Also, add a filter to disallow flushing on non-cli. The default may be changed in the future.